### PR TITLE
chore: release v0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.5](https://github.com/drewzemke/tongo/compare/v0.15.4...v0.15.5) - 2026-01-23
+
+### Other
+
+- *(cd)* add cargo caching
+- *(cd)* add x86_64-unknown-linux-musl target
+- add homebrew installation instructions to readme
+- *(nix)* read version from Cargo.toml
+
 ## [0.15.4](https://github.com/drewzemke/tongo/compare/v0.15.3...v0.15.4) - 2026-01-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3146,7 +3146,7 @@ checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tongo"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tongo"
 authors = ["Drew Zemke"]
-version = "0.15.4"
+version = "0.15.5"
 edition = "2021"
 license = "GPL-3.0"
 description = "A TUI for MongoDB"


### PR DESCRIPTION



## 🤖 New release

* `tongo`: 0.15.4 -> 0.15.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.5](https://github.com/drewzemke/tongo/compare/v0.15.4...v0.15.5) - 2026-01-23

### Other

- *(cd)* add cargo caching
- *(cd)* add x86_64-unknown-linux-musl target
- add homebrew installation instructions to readme
- *(nix)* read version from Cargo.toml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).