### PR TITLE
fix: resolve unreadable text in light terminal themes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -439,6 +439,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
 
 [[package]]
 name = "core-foundation-sys"
@@ -759,7 +765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1406,9 +1412,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -1499,7 +1505,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -1716,6 +1722,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2444,7 +2462,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2457,7 +2475,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2857,7 +2875,19 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal-light"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79307346b35bf24ed47c895c71f24653fab51c37576c7df7b5efdb8d519aee6d"
+dependencies = [
+ "coolor",
+ "crossterm",
+ "thiserror 1.0.69",
+ "xterm-query",
 ]
 
 [[package]]
@@ -2899,7 +2929,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -3165,6 +3195,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "syntect",
+ "terminal-light",
  "thiserror 2.0.16",
  "tokio",
  "toml",
@@ -3633,7 +3664,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3905,6 +3936,17 @@ name = "x11rb-protocol"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+
+[[package]]
+name = "xterm-query"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e468ba3129b3d5acd2655410cf12adccd818746e2b8d7fd4b2d22a6e3515ec98"
+dependencies = [
+ "nix 0.31.3",
+ "thiserror 1.0.69",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0.143"
 strum = "0.27.2"
 strum_macros = "0.27.2"
 syntect = "5.2.0"
+terminal-light = "1.9.0"
 thiserror = "2.0.16"
 tokio = { version = "1.47.1", features = ["full"] }
 toml = "0.9.5"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ The first time you run `tongo`, a `config.toml` will be created for you in `~/.c
 
 ### Color Themes
 
-You can fully customize the colors used in `tongo`'s UI to your liking by creating a `theme.toml` in the same directory as your configuration file. Check out [our small themes collection](./assets/themes) for some examples to get you started.
+`tongo` detects your terminal's background at startup and picks light- or dark-friendly default colors so the UI stays legible either way.
+
+You can fully customize the colors used in `tongo`'s UI to your liking by creating a `theme.toml` in the same directory as your configuration file; any colors you set there take precedence over the detected defaults. Check out [our small themes collection](./assets/themes) for some examples to get you started.
 
 
 ## Contributing

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use color_map::{ColorMap, RawColorMap};
+use color_map::{ColorMap, RawColorMap, TerminalTheme};
 use key_map::KeyMap;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, rc::Rc};
@@ -76,12 +76,24 @@ impl TryFrom<RawConfig> for Config {
     type Error = anyhow::Error;
 
     fn try_from(config: RawConfig) -> Result<Self, Self::Error> {
+        Self::from_raw(config, TerminalTheme::default())
+    }
+}
+
+impl Config {
+    /// Builds the config from raw values, using the given terminal background
+    /// theme to pick default colors. A theme provided in the user's config or
+    /// theme file still takes precedence, layered on top of these defaults.
+    ///
+    /// # Errors
+    /// Returns an error if the key mappings or theme cannot be parsed.
+    pub fn from_raw(config: RawConfig, theme: TerminalTheme) -> Result<Self> {
         let page_size = config.page_size;
         let key_map = Rc::new(config.keys.try_into()?);
         let color_map = if let Some(raw_color_map) = config.theme {
-            Rc::new(raw_color_map.try_into().context("Could not load theme")?)
+            Rc::new(ColorMap::from_raw(&raw_color_map, theme).context("Could not load theme")?)
         } else {
-            Rc::new(ColorMap::default())
+            Rc::new(ColorMap::base(theme))
         };
 
         Ok(Self {

--- a/src/config/color_map.rs
+++ b/src/config/color_map.rs
@@ -28,6 +28,15 @@ pub struct RawColorMap {
     palette: HashMap<String, String>,
 }
 
+/// The background brightness of the terminal, used to pick a legible set of
+/// default colors. Detected at startup; falls back to `Dark`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TerminalTheme {
+    #[default]
+    Dark,
+    Light,
+}
+
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, strum_macros::EnumIter)]
 pub enum ColorKey {
     // general ui
@@ -201,7 +210,50 @@ impl TryFrom<RawColorMap> for ColorMap {
     type Error = anyhow::Error;
 
     fn try_from(map: RawColorMap) -> Result<Self, Self::Error> {
+        Self::from_raw(&map, TerminalTheme::Dark)
+    }
+}
+
+impl ColorMap {
+    /// Returns the default color map for the given terminal background theme.
+    #[must_use]
+    pub fn base(theme: TerminalTheme) -> Self {
+        match theme {
+            TerminalTheme::Dark => Self::default(),
+            TerminalTheme::Light => Self::light(),
+        }
+    }
+
+    /// The default color map tuned for light-background terminals. Starts from
+    /// the (dark) default and overrides the keys that assume a dark background.
+    fn light() -> Self {
         let mut color_map = Self::default();
+        let overrides = [
+            (ColorKey::FgPrimary, Color::Black),
+            (ColorKey::FgSecondary, Color::DarkGray),
+            (ColorKey::SelectionBg, Color::Black),
+            (ColorKey::SelectionFg, Color::White),
+            (ColorKey::PanelInactiveBorder, Color::DarkGray),
+            (ColorKey::TabInactive, Color::DarkGray),
+            (ColorKey::Key, Color::Black),
+            (ColorKey::ObjectId, Color::Black),
+            (ColorKey::Punctuation, Color::DarkGray),
+            (ColorKey::DocumentsNote, Color::DarkGray),
+        ];
+        for (key, color) in overrides {
+            color_map.map.insert(key, color);
+        }
+        color_map
+    }
+
+    /// Builds a color map from user configuration, layered on top of the
+    /// defaults for the given terminal background theme.
+    ///
+    /// # Errors
+    /// Returns an error if the configuration contains an invalid palette key or
+    /// an unrecognized color or theme key.
+    pub fn from_raw(map: &RawColorMap, theme: TerminalTheme) -> Result<Self> {
+        let mut color_map = Self::base(theme);
 
         // create the palette
         let mut palette = HashMap::default();
@@ -349,6 +401,44 @@ mod tests {
             .insert("boolean".to_string(), "invalid_color".to_string());
 
         assert!(ColorMap::try_from(raw_map).is_err());
+    }
+
+    #[test]
+    fn light_theme_uses_legible_defaults() {
+        let dark = ColorMap::base(TerminalTheme::Dark);
+        let light = ColorMap::base(TerminalTheme::Light);
+
+        // dark defaults assume a dark background
+        assert_eq!(dark.get(&ColorKey::FgPrimary), Color::White);
+        assert_eq!(dark.get(&ColorKey::SelectionBg), Color::White);
+
+        // light defaults flip those to stay readable on a light background
+        assert_eq!(light.get(&ColorKey::FgPrimary), Color::Black);
+        assert_eq!(light.get(&ColorKey::Key), Color::Black);
+        assert_eq!(light.get(&ColorKey::SelectionBg), Color::Black);
+        assert_eq!(light.get(&ColorKey::SelectionFg), Color::White);
+
+        // theme-agnostic colors stay the same across themes
+        assert_eq!(
+            light.get(&ColorKey::PanelActiveBorder),
+            dark.get(&ColorKey::PanelActiveBorder)
+        );
+    }
+
+    #[test]
+    fn user_config_overrides_light_defaults() {
+        let mut raw_map = RawColorMap::default();
+        raw_map
+            .ui
+            .insert("fg-primary".to_string(), "red".to_string());
+
+        let color_map = ColorMap::from_raw(&raw_map, TerminalTheme::Light)
+            .expect("should be able to create color map");
+
+        // user override wins over the light default
+        assert_eq!(color_map.get(&ColorKey::FgPrimary), Color::Red);
+        // untouched keys still use the light default
+        assert_eq!(color_map.get(&ColorKey::Key), Color::Black);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{io::Stdout, path::PathBuf, rc::Rc};
 
 use tongo::{
     app::App,
-    config::Config,
+    config::{color_map::TerminalTheme, Config},
     model::connection::Connection,
     persistence::PersistedComponent,
     utils::storage::{get_app_data_path, FileStorage, Storage},
@@ -51,8 +51,11 @@ async fn main() -> Result<()> {
 
     let storage = FileStorage::init()?;
 
+    // detect the terminal's background brightness so default colors stay legible
+    let terminal_theme = detect_terminal_theme();
+
     // load config
-    let config: Config = storage.read_config()?.try_into()?;
+    let config: Config = Config::from_raw(storage.read_config()?, terminal_theme)?;
 
     // load connections
     let stored_connections = storage.read_connections().unwrap_or_default();
@@ -100,6 +103,28 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Queries the terminal's background color (via an OSC escape sequence) to pick
+/// a legible default color scheme. Must run before the terminal is put into raw
+/// mode / the alternate screen. Falls back to `Dark` when detection isn't
+/// possible (e.g. the terminal doesn't support the query, or output is piped).
+fn detect_terminal_theme() -> TerminalTheme {
+    match terminal_light::luma() {
+        // luma is in [0.0, 1.0]; treat brighter-than-mid backgrounds as light
+        Ok(luma) if luma > 0.6 => {
+            tracing::debug!(luma, "Detected light terminal background");
+            TerminalTheme::Light
+        }
+        Ok(luma) => {
+            tracing::debug!(luma, "Detected dark terminal background");
+            TerminalTheme::Dark
+        }
+        Err(err) => {
+            tracing::debug!(?err, "Could not detect terminal background; defaulting to dark");
+            TerminalTheme::Dark
+        }
+    }
 }
 
 #[tracing::instrument(skip())]


### PR DESCRIPTION
### Description
This Pull Request fixes the contrast and readability issues encountered when using Tongo with a light terminal theme (as reported in #21). 

Previously, some text elements (like shortcut keys on the connection screen and commands inside the menu) were using hardcoded light colors, making them invisible against a light background. 

I have updated the styles to ensure proper contrast regardless of whether the user is using a dark or light terminal background.

### Related Issue
Closes #21

### Screenshots

<img width="890" height="532" alt="dark-1" src="https://github.com/user-attachments/assets/f37208d8-1b9d-4631-8cf1-a1313eead1f2" />
<img width="892" height="527" alt="dark-2" src="https://github.com/user-attachments/assets/35dd6323-352d-40d1-b4f8-1915d2c1171f" />
<img width="894" height="530" alt="light-1" src="https://github.com/user-attachments/assets/fb728d70-7891-41f8-9f28-35d1cabaf663" />
<img width="892" height="530" alt="light-2" src="https://github.com/user-attachments/assets/83ac64be-5448-49d3-aaca-68ca2262f903" />

### Checklist
- [x] Tested with a dark terminal theme
- [x] Tested with a light terminal theme